### PR TITLE
split push_to_bkbit.yaml workflow into separate workflows

### DIFF
--- a/.github/workflows/push_gars_to_bkbit.yaml
+++ b/.github/workflows/push_gars_to_bkbit.yaml
@@ -1,24 +1,13 @@
-name: push to bkbit
-# run when the workflow named 'generating other formats' completes on a branch named main.
+name: push pydantic gars to bkbit
+
 on:
   push:
-    branches:
-      - main
     paths:
-      - 'models_py-autogen/kbmodel.py'
-  workflow_run:
-    workflows: [generating other formats]
-    types: 
-      - completed 
-    branches:
-      - main
-
+      - 'models_py-autogen/gars.py' 
 
 jobs:
-  update:
+  update_gars:
     runs-on: ubuntu-latest
-    # 'update' job will only run if the "generate other formats" workflow succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v3
@@ -29,9 +18,9 @@ jobs:
         env: 
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source_file: 'models_py-autogen/kbmodel.py'
+          source_file: 'models_py-autogen/gars.py'
           destination_repo: 'brain-bican/bkbit'
           destination_folder: 'bkbit/models/'
           user_email: 'xspuja@gmail.com' # the GitHub user email associated with the API token secret.
           user_name: 'puja-trivedi' # the GitHub username associated with the API token secret.
-          commit_message: "Updated kbmodel.py. Pushed from brain-bican/model repository"
+          commit_message: "pydantic version of gars model (gars.py) was updated. Pushed from brain-bican/model repository"

--- a/.github/workflows/push_librarygeneration_to_bkbit.yaml
+++ b/.github/workflows/push_librarygeneration_to_bkbit.yaml
@@ -1,0 +1,26 @@
+name: push pydantic library_generation to bkbit
+
+on:
+  push:
+    paths:
+      - 'models_py-autogen/library_generation.py' 
+
+jobs:
+  update_library_generation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v3
+
+      - name: Pushes to another repository
+        uses: dmnemec/copy_file_to_another_repo_action@main
+
+        env: 
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source_file: 'models_py-autogen/library_generation.py'
+          destination_repo: 'brain-bican/bkbit'
+          destination_folder: 'bkbit/models/'
+          user_email: 'xspuja@gmail.com' # the GitHub user email associated with the API token secret.
+          user_name: 'puja-trivedi' # the GitHub username associated with the API token secret.
+          commit_message: "pydantic version of library_generation model (library_generation.py) was updated. Pushed from brain-bican/model repository"


### PR DESCRIPTION
split push_to_bkbit.yaml workflow into separate workflows for each model. Now there is a workflow for each linkml model we currently have (gars and library_generation)