### PR TITLE
added 'fail-fast:false' to WF that use matrix jobs

### DIFF
--- a/.github/workflows/tests_lint.yaml
+++ b/.github/workflows/tests_lint.yaml
@@ -10,8 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10" ]
+        python-version: ["3.8", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout this repository

--- a/.github/workflows/tests_lint.yaml
+++ b/.github/workflows/tests_lint.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout this repository

--- a/.github/workflows/tests_models.yaml
+++ b/.github/workflows/tests_models.yaml
@@ -10,8 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10" ]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout this repository

--- a/.github/workflows/tests_models.yaml
+++ b/.github/workflows/tests_models.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout this repository


### PR DESCRIPTION
added 'fail-fast:false' such that all matrix jobs will run independently, and failures in one won't cancel the others.