### PR TITLE
Replace the current git diff check with git diff --cached --quiet 

### DIFF
--- a/.github/workflows/reusable-generate_other_formats.yaml
+++ b/.github/workflows/reusable-generate_other_formats.yaml
@@ -99,7 +99,7 @@ jobs:
             git add models_py-autogen/${name}.py
             git add erdiagram-autogen/${name}.md
           done
-          if ! git diff --quiet HEAD; then
+          if ! git diff --cached --quiet; then
             git commit -m "generate another formats for ${models_list} model(s)"
             if git pull --rebase; then
               git push


### PR DESCRIPTION
resolving #177 

modified the git commit logic to properly check for staged changes instead of all changes. 

- Changed `git diff --quiet HEAD` to `git diff --cached --quiet`
- This will check only staged changes (files that were `git add`) rather than all changes

This fix will ensure that:
- The workflow won't fail due to unstaged changes in other files
