### PR TITLE
added anatomical_structure to list of models that need post processing of er diagram in resuable-generate_other_formats workflow

### DIFF
--- a/.github/workflows/reusable-generate_other_formats.yaml
+++ b/.github/workflows/reusable-generate_other_formats.yaml
@@ -68,7 +68,7 @@ jobs:
             echo "jsonld-context generated";
             linkml generate pydantic ${name}.yaml > ../models_py-autogen/${name}.py;
             echo "pydantic model generated";
-            if [ ${name} = "library_generation" ] || [ ${name} = "genome_annotation" ] || [ ${name} = "bke_taxonomy" ]; then
+            if [ ${name} = "library_generation" ] || [ ${name} = "genome_annotation" ] || [ ${name} = "bke_taxonomy" ] || [ ${name} = "anatomical_structure" ]; then
               echo "Fixing erdiagrams for $name";
               python ../utils/fix_and_create_erdiagram.py;
             else


### PR DESCRIPTION
- resolving  #179 
-  added [anatomical_structure to list of models](https://github.com/brain-bican/models/blob/b0c409b9aafa156a2fb11962f0ba289eef8db344/.github/workflows/reusable-generate_other_formats.yaml#L71) that need post processing of er diagram in resuable-generate_other_formats workflow