### PR TITLE
added git stash, to resuable-generate_other_formats.yaml

### DIFF
--- a/.github/workflows/reusable-generate_other_formats.yaml
+++ b/.github/workflows/reusable-generate_other_formats.yaml
@@ -104,12 +104,16 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "generate another formats for ${models_list} model(s)"
             git status
+            # Stash any remaining local changes (including untracked files) before pulling
+            git stash --include-untracked
             if git pull --rebase; then
               git push
             else
               echo "Failed to pull --rebase, setting upstream"
               git push --set-upstream origin $BRANCH_NAME
             fi
+            # Unstash the changes so they're available for the next workflow step
+            git stash pop || echo "No stashed changes to apply"
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
- resolving #185 
- The error is due to unstaged changes after the commit because not all generated/modified files are being staged. 
- We do not want to commit all the files that are being modified/generated—because another `models `workflow will handle them BUT we need to ensure the working directory is clean before attempting a git pull --rebase or git push. Git will not allow us to pull/rebase if there are unstaged or uncommitted changes, even if we don't want to commit them in this workflow.

Solution to avoid committing all the files
- Stash the changes before pulling:  stash all local changes before running `git pull --rebase`, then optionally pop the stash after if needed.
