### PR TITLE
updated resuable-generate_other_formats such that it pulls any updates, then pushes new changes

### DIFF
--- a/.github/workflows/reusable-generate_other_formats.yaml
+++ b/.github/workflows/reusable-generate_other_formats.yaml
@@ -102,18 +102,21 @@ jobs:
             git status
           done
           if ! git diff --cached --quiet; then
-            git commit -m "generate another formats for ${models_list} model(s)"
             git status
             # Stash any remaining local changes (including untracked files) before pulling
             git stash --include-untracked
             if git pull --rebase; then
+              git stash pop || echo "No stashed changes to apply"
+              git add .
+              git commit -m "generate another formats for ${models_list} model(s)"
               git push
             else
               echo "Failed to pull --rebase, setting upstream"
+              git stash pop || echo "No stashed changes to apply"
+              git add .
+              git commit -m "generate another formats for ${models_list} model(s)"
               git push --set-upstream origin $BRANCH_NAME
             fi
-            # Unstash the changes so they're available for the next workflow step
-            git stash pop || echo "No stashed changes to apply"
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
#193 
solution:
- Always perform a `git pull --rebase` before committing and pushing, to ensure the local branch is up to date with the remote before making a new commit.

- Alternatively, after a failed push, perform a `git pull --rebase` and then retry the push.
