### PR TITLE
Update reusable-generate_yaml_model.yaml

### DIFF
--- a/.github/workflows/reusable-generate_yaml_model.yaml
+++ b/.github/workflows/reusable-generate_yaml_model.yaml
@@ -25,7 +25,6 @@ jobs:
           python -m pip install .[test]
           pip install linkml=="1.8.1" # specify the older version of linkml
           pip install git+https://github.com/brain-bican/bkbit.git
-          pip install git+https://github.com/linkml/schemasheets.git@649af7e1
 
       - name: Other installations
         run: |


### PR DESCRIPTION
removing pip install schemasheet. no longer need to overwrite the schemasheets version from bkbit