### PR TITLE
Add pan/zoom controls to Mermaid diagrams

### DIFF
--- a/.github/workflows/generate_docs.yaml
+++ b/.github/workflows/generate_docs.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,6 @@ theme:
     - content.tabs.link
 plugins:
   - search
-  - mermaid2
 
 nav:
   - Overview: index.md
@@ -26,3 +25,10 @@ nav:
     - Assertion Evidence: assertion_evidence.md
     - BKE Taxonomy: bke_taxonomy.md
 repo_url: https://github.com/brain-bican/models
+
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: "BICAN Knowledge Graph Models Documentation"
+site_url: https://brain-bican.github.io/models/
 theme:
   name: material
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,11 @@ theme:
 plugins:
   - search
   - mermaid2
-  - panzoom
+  - panzoom:
+      full_screen: true
+      always_show_hint: true
+      hint_location: "top"
+
 
 nav:
   - Overview: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,8 @@ theme:
     - content.tabs.link
 plugins:
   - search
+  - mermaid2
+  - panzoom
 
 nav:
   - Overview: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ test = [
 ]
 docs = [
     "mkdocs-material",
-    "mkdocs-mermaid2-plugin"
+    "mkdocs-mermaid2-plugin",
+    "mkdocs-panzoom-plugin"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Issue
Currently the text in the Mermaid diagrams is quite small ([example below](https://brain-bican.github.io/models/anatomical_structure/)):
<img width="1274" height="438" alt="image" src="https://github.com/user-attachments/assets/364f9a24-a417-4019-a077-f680a2e1b1d8" />

## Changes
- [x] Add the [mkdocs-panzoom](https://github.com/PLAYG0N/mkdocs-panzoom) plugin to enable panning and zooming.
- [x] Add `workflow_dispatch` to trigger docs deployment manually.
- I kept the `mermaid2` plugin but I don't think we need it since mkdocs material natively supports Mermaid diagrams with the `markdown_extension`.  See [reference](https://squidfunk.github.io/mkdocs-material/reference/diagrams/).

Preview: https://kabilar.github.io/bican-models/anatomical_structure/

cc @satra 